### PR TITLE
WIP to add lammps

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,11 +191,11 @@ We could also try a container - I will likely do both.
 
 ## TODO
 
+Grab one of these if you'd like to contribute!
+
 - A non-interactive submit needs to write a submission file (might not be needed)
 - Tweak the configs to get envars that have the cluster size (right now just hard coded to 2)
 - Test out [containers](https://chtc.cs.wisc.edu/uw-research-computing/docker-jobs)
-- LAMMPS example working
-
 
 ## License
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/converged-computing/htcondor-operator
-  newTag: latest
+  newTag: test

--- a/controllers/htcondor/htcondor.go
+++ b/controllers/htcondor/htcondor.go
@@ -164,6 +164,14 @@ func (r *HTCondorReconciler) getConfigMap(
 		data["start-manager"] = managerStart
 		data["start-execute"] = executeStart
 		data["start-submit"] = submitStart
+
+		// This will be copied into
+		// /root/secrets/token
+		//token, err := r.getToken(ctx, cluster)
+		//if err != nil || token == "" {
+		//	return cm, ctrl.Result{Requeue: true}, err
+		//}
+		//data[tokenKey] = token
 	}
 
 	// Create the config map with respective data!

--- a/controllers/htcondor/templates.go
+++ b/controllers/htcondor/templates.go
@@ -32,6 +32,9 @@ var startSubmitTemplate string
 //go:embed templates/components.sh
 var startComponents string
 
+//go:embed templates/token.sh
+var tokenTemplate string
+
 // NodeTemplate populates a node entrypoint
 type NodeTemplate struct {
 	Node        api.Node

--- a/controllers/htcondor/templates/components.sh
+++ b/controllers/htcondor/templates/components.sh
@@ -7,6 +7,10 @@
 echo "Sleeping for networking..."
 sleep 3
 
+# Copy over our token, and remove newline at top
+# mkdir -p /root/secrets
+# tr --delete '\n' < /htcondor_operator/token > /root/secrets/token
+
 # Initialization commands
 {{ .Node.Commands.Init}} > /dev/null 2>&1
 
@@ -20,16 +24,34 @@ mkdir -p ${workdir}
 {{end}}
 
 {{define "config"}}
+
+# This won't trigger to the right set of conditions in 
+# /etc/condor/config.d/01-security.conf if we set to yes
+# with yes, the basic cluster works, but parallel universe does not
+export USE_POOL_PASSWORD=yes
+
 # Shared logic to write a config across nodes
 echo "NEGOTIATOR_INTERVAL=10" >> /etc/condor/condor_config.local
-# echo "SEC_PASSWORD_FILE = $(LOCAL_DIR)/lib/condor/pool_password" >> /etc/condor/condor_config.local
 
-# Generate password
-mkdir -p /root/secrets
-# chmod 0700 /root/secrets
+# note that this container setup seems to already be using a USE_POOL_PASSWORD with host auth
+# These don't seem to work for this setup
+# echo "use security:host_based" >> /etc/condor/config.d/00-insecure.config
+
 # The top one is shown for docker-compose, the second in the config example
+mkdir -p /root/secrets
 condor_store_cred -p {{.Spec.Config.Password}} -f /root/secrets/pool_password 
 # condor_store_cred -p {{.Spec.Config.Password}} -f /var/lib/condor/pool_password
+
+# Try updating to allow TOKEN and PASSWORD
+echo "SEC_DEFAULT_AUTHENTICATION_METHODS = FS, PASSWORD, TOKEN, IDTOKENS" >> /etc/condor/config.d/01-security.conf 
+echo "ALLOW_WRITE = *" >> /etc/condor/config.d/01-security.conf 
+
+# Austin DANGER POWERS!
+echo 'ALLOW_ADVERTISE_STARTD = condor_pool@*/* $(ALLOW_ADVERTISE_STARTD)' >> /etc/condor/config.d/01-security.conf 
+echo 'ALLOW_ADVERTISE_SCHEDD = condor_pool@*/* $(ALLOW_ADVERTISE_SCHEDD)' >> /etc/condor/config.d/01-security.conf 
+echo 'ALLOW_ADVERTISE_MASTER = condor_pool@*/* $(ALLOW_ADVERTISE_MASTER)' >> /etc/condor/config.d/01-security.conf 
+
+# ALLOW_WRITE = *
 
 # TODO this should be actual cpus, not nodes
 export NUM_CPUS={{.Spec.Size}}
@@ -40,11 +62,61 @@ export NUM_CPUS={{.Spec.Size}}
 {{ end }}
 
 {{define "condor-host"}}
-
-export USE_POOL_PASSWORD=yes
 export CONDOR_HOST={{ .ClusterName }}-manager-0-0.{{ .Spec.ServiceName }}.{{ .Namespace }}.svc.cluster.local
 # export CONDOR_SERVICE_HOST=${CONDOR_HOST}
 {{ end }}
 
+{{define "approve-tokens"}}
+# This snippet will always approve token requests, if needed
+# Install jq for now - a hack to approve token requests
+yum install -y jq
+
+# Ideally we can provide this via a config or the condor_token_request_auto_approve that takes a hostname
+while true
+do
+    for requestid in $(condor_token_request_list -json | jq -r .[].RequestId); do
+        echo "yes" | condor_token_request_approve -reqid ${requestid}
+    done
+    sleep 15
+done
+{{end}}
+
+{{define "security-config"}}
+tee -a /etc/condor/config.d/01-security.conf <<EOF
+# Require authentication and integrity checking by default.
+use SECURITY : With_Authentication
+
+# Host-based security is fine in a container environment, especially if
+# we're also using a pool password or a token.
+use SECURITY : Host_Based
+# We also want root to be able to do reconfigs, restarts, etc.
+ALLOW_ADMINISTRATOR = root@$(FULL_HOSTNAME) condor@$(FULL_HOSTNAME) $(ALLOW_ADMINISTRATOR)
+
+# SEC_DEFAULT_AUTHENTICATION_METHODS = FS, PASSWORD, TOKEN
+# ALLOW_ADVERTISE_STARTD = condor_pool@*/* $(ALLOW_ADVERTISE_STARTD)
+# ALLOW_ADVERTISE_SCHEDD = condor_pool@*/* $(ALLOW_ADVERTISE_SCHEDD)
+# ALLOW_ADVERTISE_MASTER = condor_pool@*/* $(ALLOW_ADVERTISE_MASTER)
+
+# Allow public reads and writes
+ALLOW_READ = *
+ALLOW_WRITE = *
+SEC_READ_AUTHENTICATION = OPTIONAL
+
+ALLOW_ADVERTISE_MASTER = \
+    $(ALLOW_ADVERTISE_MASTER) \
+    $(ALLOW_WRITE_COLLECTOR) \
+    dockerworker@example.net
+
+ALLOW_ADVERTISE_STARTD = \
+    $(ALLOW_ADVERTISE_STARTD) \
+    $(ALLOW_WRITE_COLLECTOR) \
+    dockerworker@example.net
+
+ALLOW_ADVERTISE_SCHEDD = \
+    $(ALLOW_ADVERTISE_STARTD) \
+    $(ALLOW_WRITE_COLLECTOR) \
+    dockersubmit@example.net
+EOF
+{{end}}
 # Ohno, not DNS again!
 # 06/18/23 22:49:02 WARNING: Saw slow DNS query, which may impact entire system: getaddrinfo(htcondor-sample-manager-0-0.htc-service.htcondor-operator.svc.cluster.local) took 3.918414 seconds.

--- a/controllers/htcondor/templates/execute.sh
+++ b/controllers/htcondor/templates/execute.sh
@@ -10,6 +10,12 @@ echo "Hello, I am an execute note with $(hostname)"
 # Environment variables specific to submit
 {{template "condor-host" . }}
 
+# Target nodes for dedicated scheduler (allows for parallel universe for MPI)
+# The variable CONDOR_HOST is set in the snippet above
+# https://htcondor.readthedocs.io/en/latest/admin-manual/setting-up-special-environments.html#configuration-examples-for-dedicated-resources
+echo "DedicatedScheduler = \"DedicatedScheduler@${CONDOR_HOST}\"" >> /etc/condor/condor_config.local
+echo "STARTD_ATTRS = $(STARTD_ATTRS), DedicatedScheduler" >> /etc/condor/condor_config.local
+
 # https://github.com/htcondor/htcondor/blob/main/build/docker/services/base/start.sh
 exec bash -x /start.sh
 

--- a/controllers/htcondor/templates/manager.sh
+++ b/controllers/htcondor/templates/manager.sh
@@ -1,14 +1,11 @@
 #!/bin/sh
 
-echo "Hello, I am a server with $(hostname)"
+echo "Hello, I am a config manager node with $(hostname)"
 
 # This script handles shared start logic
 {{template "init" .}}
 
 {{template "config" .}}
-
-export USE_POOL_PASSWORD=yes
-condor_store_cred -p password -f /htcondor_operator/pool_password
 
 # See https://github.com/htcondor/htcondor/blob/main/build/docker/services/base/start.sh
 exec bash -x /start.sh

--- a/controllers/htcondor/templates/token.sh
+++ b/controllers/htcondor/templates/token.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# Start the server, and keep trying to generate token until it works
+
+export USE_POOL_PASSWORD=yes
+condor_store_cred -p {{.Spec.Config.Password}} -f /root/secrets/pool_password 
+exec bash -x /start.sh &
+
+# Create a token for the execute nodes. 
+# And this will bind to /htcondor_operator and be copied to /root/secrets/token
+retval=1
+while [ ${retval} -ne 0 ]
+  do
+    echo "Waiting for cluster to become ready to generate token...";
+    condor_token_create -authz ADVERTISE_MASTER -authz ADVERTISE_STARTD -authz READ -identity dockerworker@example.net -token dockerworker_token
+    retval=$?
+    sleep 2
+  done
+echo "HTCondor properly configured"
+echo "CUT HERE"
+cat /etc/condor/tokens.d/dockerworker_token

--- a/controllers/htcondor/token.go
+++ b/controllers/htcondor/token.go
@@ -1,0 +1,220 @@
+/*
+Copyright 2023 Lawrence Livermore National Security, LLC
+ (c.f. AUTHORS, NOTICE.LLNS, COPYING)
+
+This is part of the Flux resource manager framework.
+For details, see https://github.com/flux-framework.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package controllers
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	api "github.com/converged-computing/htcondor-operator/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+const (
+	tokenContainerName = "token-generator"
+	tokenSuffix        = "-token"
+	tokenEntrypointKey = "token-generate"
+	tokenKey           = "token"
+)
+
+// getToken brings up a one off pod to generate the access.json file
+func (r *HTCondorReconciler) getToken(ctx context.Context, cluster *api.HTCondor) (string, error) {
+
+	// This is a one time entrypoint to generate the flux curve certificate in a single pod
+	_, _, err := r.generateTokenEntrypoint(ctx, cluster, cluster.Spec.Manager)
+	if err != nil {
+		return "", err
+	}
+
+	existing := &corev1.Pod{}
+	err = r.Get(ctx, types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}, existing)
+	if err != nil {
+		command := []string{"/bin/bash", fmt.Sprintf("/htcondor_operator/%s.sh", tokenEntrypointKey)}
+		pod := r.newPodCommandRunner(cluster, cluster.Spec.Manager, command)
+		r.Log.Info("✨ Creating a new Pod Command Runner ✨", "Namespace:", pod.Namespace, "Name:", pod.Name)
+
+		// We are being bad and not checking if there are errors - we just want to get the certificate
+		r.Create(ctx, pod)
+		existing = pod
+	}
+
+	// If we get here, try to get the log output with the token
+	token, err := r.getPodLogs(ctx, existing)
+
+	// Split on token
+	fmt.Println(token)
+	parts := strings.SplitN(token, "CUT HERE", 2)
+	token = parts[1]
+
+	if token != "" {
+		fmt.Println("🌵 Generated token for execute nodes.")
+	}
+	return token, err
+}
+
+// getPodLogs gets the pod logs (with the curve cert)
+func (r *HTCondorReconciler) getPodLogs(ctx context.Context, pod *corev1.Pod) (string, error) {
+
+	// creates the clientset
+	clientset, err := kubernetes.NewForConfig(r.RESTConfig)
+	if err != nil {
+		return "", err
+	}
+
+	// Keep developer user informed what is going on.
+	r.Log.Info("Pod Logs", "Name", pod.Name)
+	r.Log.Info("Pod Logs", "Container", pod.Spec.Containers[0].Name)
+	opts := corev1.PodLogOptions{
+		Container: pod.Spec.Containers[0].Name,
+	}
+
+	// This will fail (and need to reconcile) while container is creating, etc.
+	req := clientset.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &opts)
+	podLogs, err := req.Stream(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer podLogs.Close()
+
+	buf := new(bytes.Buffer)
+	_, err = io.Copy(buf, podLogs)
+	if err != nil {
+		return "", err
+	}
+	logs := buf.String()
+	return logs, err
+}
+
+// generateTokenEntrypoint generates the config map entrypoint for the access.json
+func (r *HTCondorReconciler) generateTokenEntrypoint(
+	ctx context.Context,
+	cluster *api.HTCondor,
+	node api.Node,
+) (*corev1.ConfigMap, ctrl.Result, error) {
+
+	existing := &corev1.ConfigMap{}
+	configFullName := cluster.Name + tokenSuffix
+	err := r.Client.Get(
+		ctx,
+		types.NamespacedName{
+			Name:      configFullName,
+			Namespace: cluster.Namespace,
+		},
+		existing,
+	)
+
+	if err != nil {
+
+		// Case 1: not found yet, so we generate the pod
+		if errors.IsNotFound(err) {
+
+			data := map[string]string{}
+			tokenEntrypoint, err := generateScript(cluster, node, tokenTemplate)
+			if err != nil {
+				return existing, ctrl.Result{}, err
+			}
+			data[tokenEntrypointKey] = tokenEntrypoint
+			cm := r.createConfigMap(cluster, configFullName, data)
+			err = r.Client.Create(ctx, cm)
+			if err != nil {
+				r.Log.Error(
+					err, "❌ Failed to create token Pod Generator Entrypoint",
+					"Namespace", cm.Namespace,
+					"Name", cm.Name,
+				)
+				return existing, ctrl.Result{}, err
+			}
+			// Successful - return and requeue
+			return cm, ctrl.Result{Requeue: true}, nil
+
+		} else if err != nil {
+			r.Log.Error(err, "Failed to get token Pod Generator Entrypoint")
+			return existing, ctrl.Result{}, err
+		}
+	} else {
+		r.Log.Info(
+			"🎉 Found existing token Pod Generator Entrypoint",
+			"Namespace", existing.Namespace,
+			"Name", existing.Name,
+		)
+	}
+	return existing, ctrl.Result{}, err
+}
+
+// newPodCommandRunner creates a volume in /tmp, which doesn't seem to choke
+func (r *HTCondorReconciler) newPodCommandRunner(
+	cluster *api.HTCondor,
+	node api.Node,
+	command []string,
+) *corev1.Pod {
+
+	makeExecutable := int32(0777)
+	pullPolicy := corev1.PullIfNotPresent
+	if node.PullAlways {
+		pullPolicy = corev1.PullAlways
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cluster.Name + tokenSuffix,
+			Namespace: cluster.Namespace,
+		},
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyOnFailure,
+			Volumes: []corev1.Volume{{
+				Name: cluster.Name + tokenSuffix,
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: cluster.Name + tokenSuffix,
+						},
+						Items: []corev1.KeyToPath{{
+							Key:  tokenEntrypointKey,
+							Path: fmt.Sprintf("%s.sh", tokenEntrypointKey),
+							Mode: &makeExecutable,
+						}},
+					},
+				},
+			}},
+			Containers: []corev1.Container{{
+				Name:            tokenContainerName,
+				Image:           node.Image,
+				ImagePullPolicy: pullPolicy,
+				WorkingDir:      node.WorkingDir,
+				Stdin:           true,
+				VolumeMounts: []corev1.VolumeMount{
+					{
+						Name:      cluster.Name + tokenSuffix,
+						MountPath: "/htcondor_operator/",
+						ReadOnly:  true,
+					}},
+				TTY:     true,
+				Command: command,
+			}},
+		},
+	}
+	// Do we have pull secrets?
+	if node.PullSecret != "" {
+		pod.Spec.ImagePullSecrets = []corev1.LocalObjectReference{
+			{Name: node.PullSecret},
+		}
+	}
+	ctrl.SetControllerReference(cluster, pod, r.Scheme)
+	return pod
+}

--- a/controllers/htcondor/volumes.go
+++ b/controllers/htcondor/volumes.go
@@ -55,6 +55,10 @@ func getVolumes(cluster *api.HTCondor) []corev1.Volume {
 			Path: "start-submit.sh",
 			Mode: &makeExecutable,
 		},
+		//		{
+		//			Key:  tokenKey,
+		//			Path: "token",
+		//		},
 	}
 
 	volumes := []corev1.Volume{
@@ -70,6 +74,7 @@ func getVolumes(cluster *api.HTCondor) []corev1.Volume {
 					// /htcondor_operator/start-manager.sh
 					// /htcondor_operator/start-execute.sh
 					// /htcondor_operator/start-submit.sh
+					// /htcondor_operator/token -> /root/secrets/token
 					Items: runnerScripts,
 				},
 			},

--- a/examples/tests/lammps/README.md
+++ b/examples/tests/lammps/README.md
@@ -1,0 +1,74 @@
+# LAMMPS example
+
+Follow the getting started instructions in the README.md of the repository to create a cluster
+with JobSet installed and the htcondor-operator. Then apply the yaml:
+
+```bash
+$ kubectl apply -f htcondor.yaml
+```
+
+Shell in...
+
+```bash
+$ kubectl exec -it -n htcondor-operator htcondor-sample-submit-0-0-6fmjz bash
+```
+
+Note that we are already in the correct working directory - it doesn't have our LAMMPS files,
+but it has the same path for the execute nodes!
+
+```bash
+$ echo $PWD
+/opt/lammps/examples/reaxff/HNS
+```
+
+I was looking for a working directory [here](https://www.cl.cam.ac.uk/manuals/condor-V6_8_3-Manual/condor_submit.html) but only
+found "initialdir" and the implication was that it needed to exist on the submit node too, so for now let's just make them the same.
+Make sure your queue is ready (this can be delayed sometimes, and I don't know why)! It should look like this:
+
+```bash
+$ condor_q
+```
+```console
+-- Schedd: htcondor-sample-submit-0-0.htc-service.htcondor-operator.svc.cluster.local : <10.244.0.8:40519?... @ 06/19/23 00:53:49
+OWNER BATCH_NAME      SUBMITTED   DONE   RUN    IDLE   HOLD  TOTAL JOB_IDS
+
+Total for query: 0 jobs; 0 completed, 0 removed, 0 idle, 0 running, 0 held, 0 suspended 
+Total for all users: 0 jobs; 0 completed, 0 removed, 0 idle, 0 running, 0 held, 0 suspended
+```
+
+Write your job file:
+
+```bash
+tee -a submit.sh <<EOF
+
+# LAMMPS
+# Simple HTCondor submit description file
+# Everything with a leading # is a comment
+
+executable   = /usr/lib64/mpich/bin/mpirun
+arguments    = -np 2 --map-by socket /opt/lammps/build/lmp -v x 2 -v y 2 -v z 2 -in in.reaxc.hns -nocite
+
+output       = /tmp/lammps.out
+error        = /tmp/lammps.err
+log          = /tmp/lammps.log
+
+universe = parallel
+machine_count = 2
+request_cpus  = 1
+queue
+EOF
+```
+
+Note that if you don't write to `/tmp`, you can get a permission denied error, and you can look in `cat /var/log/condor/ShadowLog`
+to see the error. Here is how to submit:
+
+```bash
+$ condor_submit ./submit.sh
+```
+
+I'm currently debugging - sometimes condor_q doesn't work properly, and other times I don't see a .out or a .err.
+Also important for debugging, you can find some logs here:
+
+```bash
+$ ls /var/log/condor/              
+```

--- a/examples/tests/lammps/README.md
+++ b/examples/tests/lammps/README.md
@@ -36,6 +36,37 @@ Total for query: 0 jobs; 0 completed, 0 removed, 0 idle, 0 running, 0 held, 0 su
 Total for all users: 0 jobs; 0 completed, 0 removed, 0 idle, 0 running, 0 held, 0 suspended
 ```
 
+For a parallel universe job to work, we need dedicated nodes. You should see:
+
+```bash
+$ condor_status -const '!isUndefined(DedicatedScheduler)' \
+      -format "%s\t" Machine -format "%s\n" DedicatedScheduler
+```
+```console
+htcondor-sample-execute-0-0.htc-service.htcondor-operator.svls c.cluster.local     DedicatedScheduler@htcondor-sample-manager-0-0.htc-service.htcondor-operator.svc.cluster.local
+htcondor-sample-execute-0-1.htc-service.htcondor-operator.svc.cluster.local     DedicatedScheduler@htcondor-sample-manager-0-0.htc-service.htcondor-operator.svc.cluster.local
+```
+
+We can first test a simple "parallel universe" job:
+
+```
+tee -a submit.sh <<EOF
+universe = parallel
+executable = /bin/sleep
+arguments = 5
+machine_count = 2
+output = /tmp/sleep.out
+error = /tmp/sleep.err
+log = /tmp/sleep.log
+request_cpus   = 1
+
+queue
+EOF
+```
+
+That should work:
+
+
 Write your job file:
 
 ```bash

--- a/examples/tests/lammps/htcondor.yaml
+++ b/examples/tests/lammps/htcondor.yaml
@@ -1,0 +1,27 @@
+apiVersion: flux-framework.org/v1alpha1
+kind: HTCondor
+metadata:
+  labels:
+    app.kubernetes.io/name: htcondor
+    app.kubernetes.io/instance: htcondor-sample
+    app.kubernetes.io/part-of: htcondor-operator
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: htcondor-operator
+  name: htcondor-sample
+  namespace: htcondor-operator
+spec:
+
+  # One config manager, one submission node, and two workers (actual size 4)
+  size: 2
+
+  # Interactive mode to keep it running (sleeps after cluster start)
+  interactive: true
+
+  # use a container with lammps so we can submit a job
+  # We will want to more properly configure the CPU known to htcondor
+  submit:
+    image: ghcr.io/rse-ops/htcondor-submit-lammps:tag-el7
+    pullAlways: true
+  execute:    
+    image: ghcr.io/rse-ops/htcondor-execute-lammps:tag-el7
+    pullAlways: true


### PR DESCRIPTION
I'm still figuring out how this works with mpi - when I don't add something called a "universe" parallel it seems to run (I see a .out and a .err file) but there are errors with respect to a binary that is in the mpi bin (which is on the path). When I add parallel it seems to hang in the IDLE state, and all I see is the .log file. Still debugging - I am new to HTCondor so trying to get my feet wet!

What I think (maybe?) is happening is that after I ask for this universe, it tries to fall back to some kind of token auth and then fails. E.g., I see this in one of the logs:

```
TrustDomain = "htcondor-sample-manager-0-0.htc-service.htcondor-operator.svc.cluster.local"
06/19/23 04:48:31 (pid:48) attempt to connect to <10.244.0.69:9618> failed: timed out after 20 seconds.
06/19/23 04:48:31 (pid:48) ERROR: SECMAN:2003:TCP connection to collector htcondor-sample-manager-0-0.htc-service.htcondor-operator.svc.cluster.local failed.
06/19/23 04:48:31 (pid:48) Failed to start non-blocking update to <10.244.0.69:9618>.
06/19/23 04:48:31 (pid:48) SECMAN: FAILED: Received "DENIED" from server for user condor_pool@ using method IDTOKENS.
06/19/23 04:48:31 (pid:48) Failed to send RESCHEDULE to negotiator htcondor-sample-manager-0-0.htc-service.htcondor-operator.svc.cluster.local: SECMAN:2010:Received "DENIED" from server for user condor_pool@ using method IDTOKENS.
06/19/23 04:49:15 (pid:48) Received a superuser command
06/19/23 04:49:15 (pid:48) Number of Active Workers 0
```
So I'm wondering if a logical next step is to try to set up the token auth.